### PR TITLE
Updated autoschema to support recursive types

### DIFF
--- a/src/main/scala/org/coursera/autoschema/AutoSchema.scala
+++ b/src/main/scala/org/coursera/autoschema/AutoSchema.scala
@@ -159,10 +159,10 @@ abstract class AutoSchema {
             if (tpe.typeSymbol.isClass) {
               // Check if this schema is recursive
               if (previousTypes.contains(tpe.typeSymbol.fullName)) {
-                throw new IllegalArgumentException(s"Recursive types detected: $typeName")
+                Json.obj("type" -> "object", "$ref" -> tpe.typeSymbol.name.decodedName.toString)
+              } else {
+                createClassJson(tpe, previousTypes)
               }
-
-              createClassJson(tpe, previousTypes)
             } else {
               Json.obj()
             }

--- a/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
+++ b/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
@@ -203,16 +203,41 @@ class AutoSchemaTest extends AssertionsForJUnit {
 
   @Test
   def recursiveType: Unit = {
-    intercept[IllegalArgumentException] {
-      createSchema[RecursiveType]
-    }
+    createSchema[RecursiveType] ===
+      Json.obj(
+        "title" -> "RecursiveType",
+        "type" -> "object",
+        "required" -> Json.arr("param1"),
+        "properties" -> Json.obj(
+          "param1" -> Json.obj(
+            "type" -> "object",
+            "$ref" -> "RecursiveType"
+          )
+        )
+      )
   }
 
   @Test
   def mutuallyRecursiveType: Unit = {
-    intercept[IllegalArgumentException] {
-      createSchema[MutuallyRecursiveTypeOne]
-    }
+    createSchema[MutuallyRecursiveTypeOne] ===
+      Json.obj(
+        "title" -> "MutuallyRecursiveTypeOne",
+        "type" -> "object",
+        "required" -> Json.arr("param1"),
+        "properties" -> Json.obj(
+          "param1" -> Json.obj(
+            "title" -> "MutuallyRecursiveTypeTwo",
+            "type" -> "object",
+            "required" -> Json.arr("param1"),
+            "properties" -> Json.obj(
+              "param1" -> Json.obj(
+                "type" -> "object",
+                "$ref" -> "MutuallyRecursiveTypeOne"
+              )
+            )
+          )
+        )
+      )
   }
 
   @Test


### PR DESCRIPTION
I've added support for recursive types - it merely updates it with a `$ref` to the symbol simple name (title)