### PR TITLE
add cross-compilation to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,19 @@ name := "autoschema"
 
 organization := "com.sauldhernandez"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.16"
 
-crossScalaVersions := Seq("2.12.1", "2.11.8")
+crossScalaVersions := Seq("2.13.8", "2.12.16", "2.11.12")
 
-semanticVersion := Version(1, 0, 4)
+semanticVersion := Version(1, 0, 5)
 
 scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation", "-encoding", "utf8")
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.6.0-M7",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.typesafe.play" %% "play-json" % "2.7.4",
+  "org.scalatest" %% "scalatest" % "3.0.9" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.18

--- a/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
+++ b/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
@@ -24,7 +24,7 @@ import org.coursera.autoschema.annotations.FormatAs
 import org.coursera.autoschema.annotations.Term
 
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 import play.api.libs.json.Json
 import java.util.UUID


### PR DESCRIPTION
This adds cross-compilation for Scala 2.13, while keeping the 2.11 and 2.12 build.

Had to bump the dependencies (most notably Play JSON) a bit, but not all the way to latest, so that they are available for all three Scala versions.